### PR TITLE
Make re-enabling button after `stop()` optional

### DIFF
--- a/lib/ladda.js
+++ b/lib/ladda.js
@@ -38,8 +38,8 @@
                 }, delay);
                 return this;
             },
-            stop: function() {
-                button.removeAttribute("disabled");
+            stop: function(leaveDisabled) {
+                if (!leaveDisabled) button.removeAttribute("disabled");
                 button.removeAttribute("data-loading");
                 clearTimeout(timer);
                 timer = setTimeout(function() {

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'joshdellay:meteor-ladda-bootstrap',
   summary: ' Ladda bootstrap spinner for meteor ',
-  version: '1.0.3',
+  version: '1.0.4',
   git: 'https://github.com/JoshDellay/meteor-ladda-bootstrap/',
   documentation: 'README.md'
 });


### PR DESCRIPTION
Adds an optional boolean parameter to the `stop()` function, which if
`true` does not run the jQuery to remove the disabled attribute from the
button (i.e. the button remains disabled) after calling `stop()`. This
allows the enabled/disabled state of the button to be determined by a
reactive datasource, e.g. a template helper.
### Example

Call `stop(true)` on return from Meteor method:

```
Meteor.call('myMethod', function() {
  Meteor.setTimeout(function() {
    laddaButton.stop(true);
  }, 100);
});
```

Helper, `laddaEnabled()` that determines enabled/disabled state:

```
Template.myTemplate.helpers({
  laddaEnabled: function() {
    return (/* some logic */) ? true : false;
  }
});
```

Usage in template:

```
<button class="ladda-button" disabled={{laddaEnabled}} data-style="expand-right"><span class="ladda-label">Submit</span></button>
```
